### PR TITLE
Fix truncated Bootstrap script tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -98,6 +98,12 @@
     </div>
   </footer>
 
+
   <!-- Bootstrap JS bundle (includes Popper) -->
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.j
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ENjdO4Dr2bkBIFxQpeoNPZM+8ER2SlkZT1LQKzvZ6sEihWUJ6FxM6LrZ9Wm27N1E"
+    crossorigin="anonymous">
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix the cutoff `base.html` footer script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471fdefb608320b7742877ab92947c